### PR TITLE
Create image enlarger extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# TikTok Shop Image Enlarger Extension
+
+This Chrome extension enlarges product images on the TikTok Shop live product dashboard when you hover over them. A floating 500x500 pixel preview appears above the original image. Clicking anywhere else hides the preview.
+
+## Installation
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this repository folder.
+4. Visit `https://shop.tiktok.com/streamer/live/product/dashboard` and hover over a product image.
+
+The larger image will appear as a modal over the page and disappear when you click elsewhere.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,50 @@
+(function() {
+  const modal = document.createElement('div');
+  modal.id = 'picext-modal';
+  Object.assign(modal.style, {
+    position: 'absolute',
+    zIndex: '9999',
+    display: 'none',
+    border: '1px solid #ccc',
+    background: '#fff',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+    padding: '4px'
+  });
+
+  const img = document.createElement('img');
+  Object.assign(img.style, {
+    width: '500px',
+    height: '500px',
+    objectFit: 'contain'
+  });
+
+  modal.appendChild(img);
+  document.documentElement.appendChild(modal);
+
+  function showModal(src, rect) {
+    img.src = src;
+    modal.style.top = (rect.top + window.scrollY) + 'px';
+    modal.style.left = (rect.left + window.scrollX) + 'px';
+    modal.style.display = 'block';
+  }
+
+  function hideModal() {
+    modal.style.display = 'none';
+  }
+
+  document.body.addEventListener('mouseover', function(e) {
+    const container = e.target.closest('div.index-module__card-img--2QctU');
+    if (container) {
+      const image = container.querySelector('img');
+      if (image) {
+        showModal(image.src, container.getBoundingClientRect());
+      }
+    }
+  });
+
+  document.addEventListener('click', function(e) {
+    if (!modal.contains(e.target)) {
+      hideModal();
+    }
+  });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "TikTok Shop Image Enlarger",
+  "version": "1.0",
+  "description": "Enlarge product images on TikTok Shop dashboard to 500x500 pixels.",
+  "content_scripts": [
+    {
+      "matches": ["https://shop.tiktok.com/streamer/live/product/dashboard*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Chrome extension to enlarge images on TikTok Shop dashboard
- document how to install the extension

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68412fc332588322a08e23915d15a0be