### PR TITLE
Add video toggler feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 This Chrome extension enlarges product images on the TikTok Shop live product dashboard when you hover over them. A floating 400x400 pixel preview appears above the original image. Clicking anywhere else or moving the mouse away hides the preview.
 
+It also provides an optional popup to toggle the live video and audio feed on TikTok Shop pages to save system resources.
+
 ## Installation
 1. Open Chrome and navigate to `chrome://extensions`.
 2. Enable **Developer mode**.
 3. Click **Load unpacked** and select this repository folder.
 4. Visit `https://shop.tiktok.com/streamer/live/product/dashboard` and hover over a product image.
 
-The larger image will appear as a modal over the page and disappear when you click elsewhere.
+The larger image will appear as a modal over the page and disappear when you click elsewhere. Use the extension popup to enable or disable the video feed at any time.

--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,44 @@
 {
   "manifest_version": 3,
-  "name": "TikTok Shop Image Enlarger",
-  "version": "1.0",
-  "description": "Enlarge product images on TikTok Shop dashboard to 400x400 pixels.",
+  "name": "TikTok Shop Enhancer",
+  "version": "1.1",
+  "description": "Enlarge product images and toggle live video/audio on TikTok Shop.",
+  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "host_permissions": [
+    "*://*.tiktok.com/*",
+    "*://*.tiktokv.com/*",
+    "*://*.tiktokglobalshop.com/*",
+    "*://*.tiktokcdn.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icon.png",
+      "48": "icon.png",
+      "128": "icon.png"
+    },
+    "default_title": "TikTok Shop Enhancer"
+  },
   "content_scripts": [
     {
       "matches": ["https://shop.tiktok.com/streamer/live/product/dashboard*"],
       "js": ["content.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "*://shop.tiktok.com/streamer/*",
+        "*://seller-th.tiktok.com/streamer/*"
+      ],
+      "js": ["video_toggler_content.js"],
+      "all_frames": true,
+      "match_about_blank": true,
+      "run_at": "document_start"
     }
   ],
   "icons": {
     "16": "icon.png",
     "48": "icon.png",
     "128": "icon.png"
-  },
-  "action": {
-    "default_icon": {
-      "16": "icon.png",
-      "48": "icon.png",
-      "128": "icon.png"
-    },
-    "default_title": "TikTok Shop Image Zoom"
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      width: 200px;
+      padding: 15px;
+      font-family: Arial, sans-serif;
+    }
+    .toggle-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+    }
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 50px;
+      height: 24px;
+    }
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      transition: .4s;
+      border-radius: 24px;
+    }
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 16px;
+      width: 16px;
+      left: 4px;
+      bottom: 4px;
+      background-color: white;
+      transition: .4s;
+      border-radius: 50%;
+    }
+    input:checked + .slider {
+      background-color: #fe2c55;
+    }
+    input:checked + .slider:before {
+      transform: translateX(26px);
+    }
+    .status {
+      margin-top: 10px;
+      padding: 5px;
+      border-radius: 4px;
+      text-align: center;
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+  <div class="toggle-container">
+    <span>Video Feed:</span>
+    <label class="switch">
+      <input type="checkbox" id="videoToggle">
+      <span class="slider"></span>
+    </label>
+  </div>
+  <div id="status" class="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('videoToggle');
+  const statusDiv = document.getElementById('status');
+  let currentTabId = null;
+
+  function updateStatus(enabled) {
+    toggle.checked = enabled;
+    statusDiv.textContent = enabled ? 'Video feed: ON' : 'Video feed: OFF';
+    statusDiv.style.backgroundColor = enabled ? '#e6f7e6' : '#ffe6e6';
+  }
+
+  function sendMessage(message, callback) {
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      if (!tabs || !tabs.length) return;
+      currentTabId = tabs[0].id;
+      chrome.tabs.sendMessage(currentTabId, message, response => {
+        if (callback) callback(response);
+      });
+    });
+  }
+
+  toggle.addEventListener('change', () => {
+    const enabled = toggle.checked;
+    chrome.storage.sync.set({ videoEnabled: enabled });
+    sendMessage({ action: 'toggleVideo', enabled }, res => {
+      if (!res || !res.success) updateStatus(!enabled);
+    });
+  });
+
+  chrome.storage.sync.get(['videoEnabled'], result => {
+    const enabled = result.videoEnabled !== false;
+    updateStatus(enabled);
+    sendMessage({ action: 'toggleVideo', enabled });
+  });
+});

--- a/readme
+++ b/readme
@@ -1,11 +1,5 @@
-สร้าง chrome extension
-ที่จะสามารถขยายรูปของเวป https://shop.tiktok.com/streamer/live/product/dashboard
-ที่มีขนาดเล็ก ให้มีขนาดใหญ่ขึ้น ประมาณ 500x500 px
+สร้าง chrome extension ที่จะสามารถขยายรูปของเวป https://shop.tiktok.com/streamer/live/product/dashboard ที่มีขนาดเล็ก ให้มีขนาดใหญ่ขึ้น ประมาณ 500x500 px
 
-โดยจะทำงานจาก <div> ตัวอย่างนี้
-<div class="index-module__card-img--2QctU"><img src="https://p16-oec-va.ibyteimg.com/tos-maliva-i-o3syd03w52-us/3d66eb696f4d4581888c748ceb5cc663~tplv-o3syd03w52-resize-jpeg:300:300.jpeg?dr=15584&amp;nonce=86143&amp;refresh_token=8447087f76b8e136bb1ad23e6d0b0236&amp;from=1523225687&amp;idc=my2&amp;ps=933b5bde&amp;shcp=9b759fb9&amp;shp=5aca9457&amp;t=555f072d" class="w-full"></div>
+เมื่อเลื่อนเม้าส์ไปบนภาพ จะมีภาพขนาดใหญ่แสดงแบบลอยเหนือหน้าเว็บ และหายไปเมื่อคลิกที่อื่น
 
-เมื่อนำเม้าส์ไปวางไว้เหนือภาพที่เกิดขึ้นจาก <div> ตัวอย่างนี้
-ให้ขยายภาพขึ้น เป็น 500x500 px
-โดยเป็นภาพลอยขึ้นมาในลักษณะ modal เหนือภาพเดิม และไม่ไปยุ่งกับโครงสร้างเดิมของหน้าเวป
-เมื่อนำเม้าส์ไปคลิกที่อื่น ภาพหรือ modal นี้จะหายไป
+นอกจากนี้ ยังมี popup ของ extension สำหรับปิดหรือเปิดวิดีโอและเสียงในหน้าไลฟ์ TikTok Shop ได้

--- a/video_toggler_content.js
+++ b/video_toggler_content.js
@@ -1,0 +1,83 @@
+(function() {
+  'use strict';
+  if (window.__tiktokVideoTogglerInjected) return;
+  window.__tiktokVideoTogglerInjected = true;
+  window.__tiktokVideoTogglerState = window.__tiktokVideoTogglerState || {
+    enabled: true,
+    isInitialized: false
+  };
+
+  const currentState = window.__tiktokVideoTogglerState;
+
+  function toggleVideoContainer(show) {
+    const videoSelectors = [
+      '.live-room-video-container',
+      '.video-feed-container',
+      'video',
+      'iframe[src*="tiktok.com"]',
+      '.video-container',
+      '[class*="video"][class*="container"], [class*="player"][class*="container"]'
+    ];
+
+    const audioSelectors = [
+      'audio',
+      'video',
+      'iframe[src*="tiktok.com"]',
+      '[class*="audio"], [class*="volume"]'
+    ];
+
+    videoSelectors.forEach(selector => {
+      document.querySelectorAll(selector).forEach(el => {
+        el.style.display = show ? '' : 'none';
+        if (el.tagName === 'VIDEO') {
+          if (show) {
+            el.play().catch(()=>{});
+          } else {
+            el.pause();
+          }
+        }
+      });
+    });
+
+    audioSelectors.forEach(selector => {
+      document.querySelectorAll(selector).forEach(el => {
+        if (el.muted !== undefined) {
+          el.muted = !show;
+        }
+        if (el.tagName === 'VIDEO' && !show) {
+          el.pause();
+        }
+      });
+    });
+  }
+
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === 'toggleVideo') {
+      currentState.enabled = request.enabled;
+      toggleVideoContainer(request.enabled);
+      sendResponse({ success: true });
+      return true;
+    }
+    if (request.action === 'getState') {
+      sendResponse({ enabled: currentState.enabled });
+      return true;
+    }
+    if (request.action === 'ping') {
+      sendResponse({ pong: true });
+      return true;
+    }
+    return false;
+  });
+
+  function initialize() {
+    if (currentState.isInitialized) return;
+    currentState.isInitialized = true;
+    toggleVideoContainer(currentState.enabled);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialize);
+  } else {
+    initialize();
+  }
+})();


### PR DESCRIPTION
## Summary
- integrate a popup to control the live video/audio feed
- update manifest with permissions and new scripts
- implement content script that can hide video and mute audio
- update documentation

## Testing
- `npm --version`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d1a443a88322b35fd95ff13744d2